### PR TITLE
Enhancement: Fixes #26, Junkbot does not turn around on edges

### DIFF
--- a/src/Junkbot/Game/World/Actors/JunkbotActor.cs
+++ b/src/Junkbot/Game/World/Actors/JunkbotActor.cs
@@ -237,6 +237,7 @@ namespace Junkbot.Game.World.Actors
                         // No floor ahead... turn around!
                         //
                         TurnAround();
+                        return;
                     }
                 }
             }
@@ -244,6 +245,7 @@ namespace Junkbot.Game.World.Actors
             if (!(floor is BrickActor))
             {
                 TurnAround();
+                return;
             }
 
             // Check target is free


### PR DESCRIPTION
Fixes: https://github.com/rozniak/Junkbot/issues/26

As we weren't returning after executing `TurnAround`, it was entering `!(floor is BrickActor)` and executing `TurnAround` again. 

![Animation](https://user-images.githubusercontent.com/32589891/167309231-2e62f667-45f0-445c-a5cf-dff9c04996b6.gif)

